### PR TITLE
[fix]Ignore defaultProps error

### DIFF
--- a/src/components/TaskList/MonthTaskList.tsx
+++ b/src/components/TaskList/MonthTaskList.tsx
@@ -75,6 +75,9 @@ const MonthTaskList: React.FC<MonthTaskListProps> = (props: MonthTaskListProps) 
 
     }, []);
 
+    // @ts-ignore fix for defaultProps warning: https://github.com/wix/react-native-calendars/issues/2455
+    ExpandableCalendar.defaultProps = undefined;
+
     return (
         <CalendarProvider date={new Date().toDateString()}>
             <View style={styles.calendarWrapper}>


### PR DESCRIPTION
Disable annoying warning while we naively wait for the fix.

[Bug report](https://github.com/wix/react-native-calendars/issues/2455)